### PR TITLE
Switch back from the forked testground to the original one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,15 +807,6 @@ checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "ipnetwork"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "ipnetwork"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
@@ -1511,7 +1502,7 @@ version = "0.1.0"
 dependencies = [
  "discv5",
  "if-addrs",
- "ipnetwork 0.18.0",
+ "ipnetwork",
  "serde",
  "serde_json",
  "testground",
@@ -1529,7 +1520,7 @@ dependencies = [
  "clap",
  "futures",
  "influxdb",
- "ipnetwork 0.19.0",
+ "ipnetwork",
  "log",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,7 +1511,7 @@ version = "0.1.0"
 dependencies = [
  "discv5",
  "if-addrs",
- "ipnetwork",
+ "ipnetwork 0.18.0",
  "serde",
  "serde_json",
  "testground",
@@ -1515,12 +1524,12 @@ dependencies = [
 [[package]]
 name = "testground"
 version = "0.2.0"
-source = "git+https://github.com/ackintosh/sdk-rust.git?rev=a86e5ff37172b2c42880eae22e630fc936da40ba#a86e5ff37172b2c42880eae22e630fc936da40ba"
+source = "git+https://github.com/testground/sdk-rust.git?rev=1aa09bef881d04272ad6d2ab35e770de2a2f5eb1#1aa09bef881d04272ad6d2ab35e770de2a2f5eb1"
 dependencies = [
  "clap",
  "futures",
  "influxdb",
- "ipnetwork",
+ "ipnetwork 0.19.0",
  "log",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # TODO: update discv5 once the PR is merged: https://github.com/sigp/discv5/pull/110
 discv5 = { git = "https://github.com/ackintosh/discv5.git", branch = "fix-issue-108" }
 if-addrs = "0.7.0"
-ipnetwork = "0.18.0"
+ipnetwork = "0.19.0"
 serde = "1.0.136"
 serde_json = "1.0.79"
 # TODO: Update testground once the next version of v0.1.1 has been released.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ if-addrs = "0.7.0"
 ipnetwork = "0.18.0"
 serde = "1.0.136"
 serde_json = "1.0.79"
-# TODO: update testground once the PR is merged: https://github.com/testground/sdk-rust/pull/11
-testground = { git = "https://github.com/ackintosh/sdk-rust.git", rev = "a86e5ff37172b2c42880eae22e630fc936da40ba" }
+# TODO: Update testground once the next version of v0.1.1 has been released.
+testground = { git = "https://github.com/testground/sdk-rust.git", rev = "1aa09bef881d04272ad6d2ab35e770de2a2f5eb1" }
 tokio = { version = "1.17.0", features = ["macros"] }
 tokio-stream = "0.1.8"
 tracing = "0.1.33"


### PR DESCRIPTION
As https://github.com/testground/sdk-rust/pull/11 has been merged, I switched back to the original repo from the forked one.