### PR TITLE
Check whether the target exists in the routing table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,11 +113,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 key.log2_distance(&target_key).expect("Distance")
             );
 
-            let enrs = discv5
-                .find_node(target.enr.node_id())
-                .await
-                .expect("FINDNODE query");
-            info!("ENRs: {:?}", enrs);
+            if let Some(enr) = discv5.find_enr(&target.enr.node_id()) {
+                info!(
+                    "The target is already exists in the routing table. ENR: {:?}",
+                    enr
+                );
+            } else {
+                let enrs = discv5
+                    .find_node(target.enr.node_id())
+                    .await
+                    .expect("FINDNODE query");
+                info!("ENRs: {:?}", enrs);
+            }
         }
     }
 


### PR DESCRIPTION
Check whether the target exists in the routing table before call FINDNODE query.

Without the check, "Requested a node find itself" error will happen if the target already exists in the routing table.