### PR TITLE
Update testground

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,7 +1520,8 @@ dependencies = [
 [[package]]
 name = "testground"
 version = "0.2.0"
-source = "git+https://github.com/testground/sdk-rust.git?rev=5c50ba4f63d2aff6b815cfbfcb0c8f9e4d73809e#5c50ba4f63d2aff6b815cfbfcb0c8f9e4d73809e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9b61271f34f69d90b003470d06a192597a5797d71841c4256e059957f890c8"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ if-addrs = "0.7.0"
 ipnetwork = "0.19.0"
 serde = "1.0.137"
 serde_json = "1.0.81"
-# TODO: Update testground once the next version of v0.1.1 has been released.
-testground = { git = "https://github.com/testground/sdk-rust.git", rev = "5c50ba4f63d2aff6b815cfbfcb0c8f9e4d73809e" }
+testground = "0.2.0"
 tokio = { version = "1.18.2", features = ["macros"] }
 tokio-stream = "0.1.8"
 tracing = "0.1.33"


### PR DESCRIPTION
v0.2.0
https://github.com/testground/sdk-rust/releases/tag/v0.2.0